### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/pypeg/benchmarkanalyzer.py
+++ b/pypeg/benchmarkanalyzer.py
@@ -45,8 +45,7 @@ def standarddeviation(iterable):
 
 
 def confidentinterval(iterable, percentage):
-    sortedlist = iterable[:]  # dont want to mess up the actual list
-    sortedlist.sort()
+    sortedlist = sorted(iterable[:])  # dont want to mess up the actual list
     index = int(float(percentage)/100 * len(sortedlist))+1
     return sortedlist[index]
 

--- a/pypeg/parser.py
+++ b/pypeg/parser.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from subprocess import check_output
 from sys import argv
 from os import chdir
@@ -8,7 +9,7 @@ from charlistelement import SingleChar, CharRange
 
 
 def line_to_instruction(line):
-    print line
+    print(line)
     if "':'" in line:  # escape before split
         line = replace(line, "':'", "'#'")
         labelsplit = line.split(":")

--- a/pypeg/stackentry.py
+++ b/pypeg/stackentry.py
@@ -76,7 +76,7 @@ class PcTuple(object):
 
     @jit.elidable
     def discard_all_but_one(self):
-        while 1:
+        while True:
             if self.prev is None:
                 return self
             self = self.prev

--- a/pypeg/target.py
+++ b/pypeg/target.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import time
 from rpython.rlib import jit, rgc
@@ -13,7 +14,7 @@ def main(argv):
         if argv[i] == "--jit":
             jitarg = argv[i + 1]
             del argv[i: i+2]
-            print jitarg, argv
+            print(jitarg, argv)
             jit.set_user_param(None, jitarg)
         if argv[i] == "--time":
             printtime = True
@@ -45,10 +46,10 @@ def main(argv):
     else:
         gct2 = 0
 
-    print output
+    print(output)
     if printtime:
-        print "time:", t2 - t1
-        print "gc time:", (gct2 - gct1) / 1000.    
+        print("time:", t2 - t1)
+        print("gc time:", (gct2 - gct1) / 1000.)    
     return 0
 
 

--- a/pypeg/vm.py
+++ b/pypeg/vm.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from utils import runpattern
 from parser import parse, relabel
 from stackentry import ChoicePoint, Bottom
@@ -84,7 +85,7 @@ def run(instructionlist, inputstring, index=0, flags=Flags()):
             print("Instruction: "+str(instructionlist[pc]))
             print("Captures: "+str(captures))
             if fail:
-                print "FAIL"
+                print("FAIL")
         if fail:
             fail = False
             if choice_points:
@@ -111,7 +112,7 @@ def run(instructionlist, inputstring, index=0, flags=Flags()):
                             + "with value "+str(pc))
         instruction = instructionlist[jit.promote(pc)]
         if flags.debug:
-            print instruction
+            print(instruction)
         if instruction.name == "char":
             if flags.optimize_char:
                 n = look_for_chars(instructionlist, pc)
@@ -362,7 +363,7 @@ def processcaptures(captures, inputstring, flags=Flags()):
     #returnlist = []
     out = rstring.StringBuilder()
     if flags.debug:
-        print captures
+        print(captures)
     while captures.prev is not None:
         if isinstance(captures, SimpleCapture):
             size = captures.get_size()
@@ -391,4 +392,4 @@ if __name__ == "__main__":
     inputstring = inputstring.strip()
     captures = runbypattern(pattern, inputstring).captures
     output = processcaptures(captures, inputstring)
-    print output
+    print(output)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.